### PR TITLE
Work towards being able to generate from a fn.

### DIFF
--- a/src/data/source.rs
+++ b/src/data/source.rs
@@ -562,4 +562,12 @@ mod tests {
             spans
         );
     }
+
+    #[test]
+    fn info_source_object_safety() {
+        let mut p = InfoRecorder::new(RngSource::new());
+        let obj: &mut InfoSource = &mut p;
+
+        let _ = obj.draw_u8();
+    }
 }

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -201,6 +201,12 @@ mod tests {
             debug!("<- Tracer::draw");
             res
         }
+
+        /// Does this even work?
+        fn range(&mut self, f: &mut FnMut(&mut InfoSource)) {
+            f(self);
+            unimplemented!("Tracer::range");
+        }
     }
 
     #[test]

--- a/tests/generators.rs
+++ b/tests/generators.rs
@@ -253,6 +253,11 @@ impl<G: InfoSource> InfoSource for RegionCounter<G> {
         self.cnt += 1;
         self.src.draw(sink)
     }
+
+    fn range(&mut self, f: &mut FnMut(&mut InfoSource)) {
+        f(self);
+        unimplemented!("RegionCounter::range");
+    }
 }
 
 #[test]


### PR DESCRIPTION
We'd find it really useful to have ad-hoc generators, so you can do something like this:

```rust
generators::from_fn(|src| {
let foo = u8s().generate(src)?;
let bar = strings().generate(src)?;
Ok(Stuff { foo, bar })
})
```

* We'll need to make `InfoSource` object safe, so it can be passed as a `&mut dyn InfoSource` to the fn contained within `FnMut`.
* This is because we can't reify a closure that is generic in it's arguments–the nearest we can get is  a trait object.

The plan from here is to either start/end methods, a start with a scopeguard object, or a `    fn range(&mut self, &mut FnMut(&mut InfoSource))` where we can track the ranges and emit the value around the side.